### PR TITLE
Add a hidden pref for unloading pinned tabs

### DIFF
--- a/defaults/preferences/prefs.js
+++ b/defaults/preferences/prefs.js
@@ -8,6 +8,7 @@ pref("extensions.bartab.findClosestLoadedTab", true);
 pref("extensions.bartab.loadOnSelectDelay", 0);
 pref("extensions.bartab.migrated", false);
 pref("extensions.bartab.unloadOnlyVisibleTabs", true);
+pref("extensions.bartab.unloadPinnedTabs", true);
 
 // https://developer.mozilla.org/en/Localizing_extension_descriptions
 pref("extensions.bartap@philikon.de.description", "chrome://bartab/locale/overlay.properties");

--- a/modules/prototypes.js
+++ b/modules/prototypes.js
@@ -195,7 +195,8 @@ BarTabHandler.prototype = {
     if (aTab.getAttribute("ontab") == "true") {
       return;
     }
-    if (BarTabUtils.whiteListed(aTab.linkedBrowser.currentURI)) {
+    if (BarTabUtils.whiteListed(aTab.linkedBrowser.currentURI)
+        || !BarTabUtils.getPref("unloadPinnedTabs") && aTab.pinned) {
       return;
     }
 


### PR DESCRIPTION
Defaults to `true` to maintain the current behavior.

I didn't want to bother with the pref pane UI just yet, so this is just a hidden pref for now.
  